### PR TITLE
Fix for testobject-appium-java-api

### DIFF
--- a/src/main/java/org/testobject/api/TestObjectClient.java
+++ b/src/main/java/org/testobject/api/TestObjectClient.java
@@ -1,14 +1,11 @@
 package org.testobject.api;
 
-import org.testobject.rest.api.appium.common.data.*;
 import org.testobject.rest.api.model.*;
 import org.testobject.rest.api.resource.v2.ApiBatchResource.InstrumentationTestSuiteRequest;
 
 import java.io.Closeable;
 import java.io.File;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
 public interface TestObjectClient extends Closeable {
@@ -41,32 +38,6 @@ public interface TestObjectClient extends Closeable {
 	//
 
 	String uploadFile(String apiKey, File apk);
-
-	//
-	// AppiumReportResource
-	//
-
-	SuiteReport startAppiumSuite(long suiteId, Optional<String> appId, Set<Test> tests);
-
-	SuiteReport finishAppiumSuite(long suiteId, SuiteReport.Id suiteReportId);
-
-	TestReport finishAppiumTestReport(long suiteId, SuiteReport.Id suiteReportId, TestReport.Id testReportId, TestResult testResult);
-
-	//
-	// AppiumSessionResource
-	//
-
-	void updateTestReportStatus(String sessionId, boolean passed);
-
-	void updateTestReportName(String sessionId, String suiteName, String testName);
-
-	//
-	// AppiumSuiteResource
-	//
-
-	Set<DataCenterSuite> readSuiteDeviceDescriptorIds(long suiteId);
-
-	Suite updateSuite(long suiteId, Suite suite);
 
 	//
 	// AppStorageResource

--- a/src/main/java/org/testobject/api/TestObjectClientImpl.java
+++ b/src/main/java/org/testobject/api/TestObjectClientImpl.java
@@ -16,7 +16,6 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
-import org.testobject.rest.api.appium.common.data.*;
 import org.testobject.rest.api.model.*;
 import org.testobject.rest.api.resource.*;
 import org.testobject.rest.api.resource.v2.*;
@@ -28,8 +27,6 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import java.io.*;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -41,9 +38,6 @@ public class TestObjectClientImpl implements TestObjectClient {
 	private final ApiBatchReportResource apiBatchReportResource;
 	private final ApiBatchResource apiBatchResource;
 	private final ApiUploadResource apiUploadResource;
-	private final AppiumReportResource appiumReportResource;
-	private final AppiumSessionResource appiumSessionResource;
-	private final AppiumSuiteResource appiumSuiteResource;
 	private final AppStorageResource appStorageResource;
 	private final InstrumentationResource instrumentationResource;
 
@@ -62,9 +56,6 @@ public class TestObjectClientImpl implements TestObjectClient {
 		apiBatchReportResource = new ApiBatchReportResource(target);
 		apiBatchResource = new ApiBatchResource(target);
 		apiUploadResource = new ApiUploadResource(target);
-		appiumReportResource = new AppiumReportResource(target);
-		appiumSessionResource = new AppiumSessionResource(target);
-		appiumSuiteResource = new AppiumSuiteResource(target);
 		appStorageResource = new AppStorageResource(target);
 		instrumentationResource = new InstrumentationResource(target);
 
@@ -119,42 +110,6 @@ public class TestObjectClientImpl implements TestObjectClient {
 	@Override
 	public String uploadFile(String apiKey, File apk) {
 		return apiUploadResource.uploadFile(apiKey, apk);
-	}
-
-	@Override
-	public SuiteReport startAppiumSuite(long suiteId, Optional<String> appId, Set<Test> tests) {
-		return appiumReportResource.startAppiumSuite(suiteId, appId, tests);
-	}
-
-	@Override
-	public SuiteReport finishAppiumSuite(long suiteId, SuiteReport.Id suiteReportId) {
-		return appiumReportResource.finishAppiumSuite(suiteId, suiteReportId);
-	}
-
-	@Override
-	public TestReport finishAppiumTestReport(long suiteId, SuiteReport.Id suiteReportId, TestReport.Id testReportId,
-			TestResult testResult) {
-		return appiumReportResource.finishAppiumTestReport(suiteId, suiteReportId, testReportId, testResult);
-	}
-
-	@Override
-	public void updateTestReportStatus(String sessionId, boolean passed) {
-		appiumSessionResource.updateTestReportStatus(sessionId, passed);
-	}
-
-	@Override
-	public void updateTestReportName(String sessionId, String suiteName, String testName) {
-		appiumSessionResource.updateTestReportName(sessionId, suiteName, testName);
-	}
-
-	@Override
-	public Set<DataCenterSuite> readSuiteDeviceDescriptorIds(long suiteId) {
-		return appiumSuiteResource.readDeviceDescriptorIds(suiteId);
-	}
-
-	@Override
-	public Suite updateSuite(long suiteId, Suite suite) {
-		return appiumSuiteResource.updateSuite(suiteId, suite);
 	}
 
 	@Override

--- a/src/main/java/org/testobject/rest/api/resource/v2/AppiumReportResource.java
+++ b/src/main/java/org/testobject/rest/api/resource/v2/AppiumReportResource.java
@@ -1,5 +1,6 @@
 package org.testobject.rest.api.resource.v2;
 
+import org.testobject.rest.api.RestClient;
 import org.testobject.rest.api.appium.common.data.SuiteReport;
 import org.testobject.rest.api.appium.common.data.Test;
 import org.testobject.rest.api.appium.common.data.TestReport;
@@ -14,17 +15,17 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
 public class AppiumReportResource {
 
-	private final WebTarget target;
+	private final RestClient client;
 
-	public AppiumReportResource(WebTarget target) {
-		this.target = target;
+	public AppiumReportResource(RestClient client) {
+		this.client = client;
 	}
 
 	/**
 	 * Start a new suite execution including its test executions
 	 */
 	public SuiteReport startAppiumSuite(long suiteId, Optional<String> appId, Set<Test> tests) {
-		WebTarget target = this.target
+		WebTarget target = client
 				.path("v2")
 				.path("appium")
 				.path("suites").path(Long.toString(suiteId))
@@ -44,7 +45,7 @@ public class AppiumReportResource {
 	 * Marks all test executions contained in the specified suite execution as finished
 	 */
 	public SuiteReport finishAppiumSuite(long suiteId, SuiteReport.Id suiteReportId) {
-		return target
+		return client
 				.path("v2")
 				.path("appium")
 				.path("suites").path(Long.toString(suiteId))
@@ -59,7 +60,7 @@ public class AppiumReportResource {
 	 */
 	public TestReport finishAppiumTestReport(long suiteId, SuiteReport.Id batchReportId, TestReport.Id testReportId,
 			TestResult testResult) {
-		return target
+		return client
 				.path("v2")
 				.path("appium")
 				.path("suites").path(Long.toString(suiteId))

--- a/src/main/java/org/testobject/rest/api/resource/v2/AppiumSessionResource.java
+++ b/src/main/java/org/testobject/rest/api/resource/v2/AppiumSessionResource.java
@@ -1,7 +1,8 @@
 package org.testobject.rest.api.resource.v2;
 
+import org.testobject.rest.api.RestClient;
+
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -10,14 +11,14 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
 public class AppiumSessionResource {
 
-	private final WebTarget target;
+	private final RestClient client;
 
-	public AppiumSessionResource(WebTarget target) {
-		this.target = target;
+	public AppiumSessionResource(RestClient client) {
+		this.client = client;
 	}
 
 	public void updateTestReportStatus(String sessionId, boolean passed) {
-		target
+		client
 				.path("v2")
 				.path("appium")
 				.path("session").path(sessionId)
@@ -31,7 +32,7 @@ public class AppiumSessionResource {
 		values.put("suiteName", suiteName);
 		values.put("testName", testName);
 
-		target
+		client
 				.path("v2")
 				.path("appium")
 				.path("session").path(sessionId)

--- a/src/main/java/org/testobject/rest/api/resource/v2/AppiumSuiteResource.java
+++ b/src/main/java/org/testobject/rest/api/resource/v2/AppiumSuiteResource.java
@@ -1,11 +1,11 @@
 package org.testobject.rest.api.resource.v2;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.testobject.rest.api.RestClient;
 import org.testobject.rest.api.appium.common.data.DataCenterSuite;
 import org.testobject.rest.api.appium.common.data.Suite;
 
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import java.util.Set;
 
@@ -13,17 +13,17 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
 public class AppiumSuiteResource {
 
-	private final WebTarget target;
+	private final RestClient client;
 
-	public AppiumSuiteResource(WebTarget target) {
-		this.target = target;
+	public AppiumSuiteResource(RestClient client) {
+		this.client = client;
 	}
 
 	/**
 	 * Returns the IDs of the devices which you had selected for the specified suite
 	 */
 	public Set<DataCenterSuite> readDeviceDescriptorIds(long suiteId) {
-		return target
+		return client
 				.path("v2")
 				.path("appium")
 				.path("suites").path(Long.toString(suiteId))
@@ -37,7 +37,7 @@ public class AppiumSuiteResource {
 	 * Updates the properties of a suite
 	 */
 	public Suite updateSuite(long suiteId, Suite suite) {
-		return target
+		return client
 				.path("v2")
 				.path("appium")
 				.path("suites").path(Long.toString(suiteId))

--- a/src/test/java/org/testobject/api/TestObjectClientTest.java
+++ b/src/test/java/org/testobject/api/TestObjectClientTest.java
@@ -102,20 +102,6 @@ public class TestObjectClientTest {
 	}
 
 	@Test @Ignore
-	public void testUpdateTestReportStatus() {
-		long testReportId = 1;
-		String sessionId = "sessionId";
-
-		client.updateTestReportStatus(sessionId, false);
-		AppiumTestReport appiumTestReport = client.getTestReport(USER_ID, PROJECT_ID, testReportId, API_KEY).getReport();
-		assertEquals("FAILURE", appiumTestReport.getStatus());
-
-		client.updateTestReportStatus(sessionId, true);
-		appiumTestReport = client.getTestReport(USER_ID, PROJECT_ID, testReportId, API_KEY).getReport();
-		assertEquals("SUCCESS", appiumTestReport.getStatus());
-	}
-
-	@Test @Ignore
 	public void testStartSuite() {
 		long suiteId = 1;
 


### PR DESCRIPTION
We shouldn't instantiate these 3 classes in the interface as before. They are intended to be used in the `testobject-appium-java-api`