### PR TITLE
Add travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TestObject Java Api
+# TestObject Java Api [![Build Status](https://travis-ci.org/saucelabs/testobject-java-api.svg?branch=master)](https://travis-ci.org/saucelabs/testobject-java-api)
 
 
 ## Installation


### PR DESCRIPTION
Added this travis link

   [![Build Status](https://travis-ci.org/saucelabs/testobject-java-api.svg?branch=master)](https://travis-ci.org/saucelabs/testobject-java-api)  

to the readme to reflect the build status. Good idea?