### PR TITLE
Don't use google here so we don't need to use guava in the testobject-appium-java-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.testobject</groupId>
 	<artifactId>testobject-java-api</artifactId>
-	<version>0.2.0</version>
+	<version>0.2.1</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/testobject/api/TestObjectClientImpl.java
+++ b/src/main/java/org/testobject/api/TestObjectClientImpl.java
@@ -1,6 +1,5 @@
 package org.testobject.api;
 
-import jersey.repackaged.com.google.common.base.Preconditions;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
@@ -30,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -162,8 +162,11 @@ public class TestObjectClientImpl implements TestObjectClient {
 			throws TimeoutException {
 
 		long waitTimeoutMinutes = TimeUnit.MILLISECONDS.toMinutes(waitTimeoutMs);
-		Preconditions.checkArgument(waitTimeoutMinutes <= TimeUnit.HOURS.toMinutes(2),
-				String.format("The timeout should be a reasonable value: no more than 120 minutes. Got %d minutes.", waitTimeoutMinutes));
+		boolean expression = waitTimeoutMinutes <= HOURS.toMinutes(2);
+		if (!expression) {
+			String errorMessage = "Timeout should be a reasonable value: no more than 120 minutes. Got " + waitTimeoutMinutes + " minutes.";
+			throw new IllegalArgumentException(String.valueOf(errorMessage));
+		}
 
 		long start = now();
 		while ((now() - start) < waitTimeoutMs) {

--- a/src/main/java/org/testobject/api/TestObjectClientImpl.java
+++ b/src/main/java/org/testobject/api/TestObjectClientImpl.java
@@ -29,9 +29,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.*;
 
 public class TestObjectClientImpl implements TestObjectClient {
 
@@ -162,10 +160,10 @@ public class TestObjectClientImpl implements TestObjectClient {
 			throws TimeoutException {
 
 		long waitTimeoutMinutes = TimeUnit.MILLISECONDS.toMinutes(waitTimeoutMs);
-		boolean expression = waitTimeoutMinutes <= HOURS.toMinutes(2);
-		if (!expression) {
+		boolean timeoutTooLong = waitTimeoutMinutes <= HOURS.toMinutes(2);
+		if (!timeoutTooLong) {
 			String errorMessage = "Timeout should be a reasonable value: no more than 120 minutes. Got " + waitTimeoutMinutes + " minutes.";
-			throw new IllegalArgumentException(String.valueOf(errorMessage));
+			throw new IllegalArgumentException(errorMessage);
 		}
 
 		long start = now();

--- a/src/main/java/org/testobject/api/TestObjectClientImpl.java
+++ b/src/main/java/org/testobject/api/TestObjectClientImpl.java
@@ -160,8 +160,8 @@ public class TestObjectClientImpl implements TestObjectClient {
 			throws TimeoutException {
 
 		long waitTimeoutMinutes = TimeUnit.MILLISECONDS.toMinutes(waitTimeoutMs);
-		boolean timeoutTooLong = waitTimeoutMinutes <= HOURS.toMinutes(2);
-		if (!timeoutTooLong) {
+		boolean timeoutTooLong = waitTimeoutMinutes > HOURS.toMinutes(2);
+		if (timeoutTooLong) {
 			String errorMessage = "Timeout should be a reasonable value: no more than 120 minutes. Got " + waitTimeoutMinutes + " minutes.";
 			throw new IllegalArgumentException(errorMessage);
 		}

--- a/src/main/java/org/testobject/rest/api/appium/common/data/Id.java
+++ b/src/main/java/org/testobject/rest/api/appium/common/data/Id.java
@@ -1,14 +1,15 @@
 package org.testobject.rest.api.appium.common.data;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import jersey.repackaged.com.google.common.base.Preconditions;
 
 public abstract class Id<T> {
 
 	private final T value;
 
 	protected Id(T value) {
-		Preconditions.checkNotNull(value);
+		if (value == null) {
+			throw new NullPointerException();
+		}
 		this.value = value;
 	}
 

--- a/src/main/java/org/testobject/rest/api/appium/common/data/SuiteReport.java
+++ b/src/main/java/org/testobject/rest/api/appium/common/data/SuiteReport.java
@@ -1,11 +1,10 @@
 package org.testobject.rest.api.appium.common.data;
 
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jersey.repackaged.com.google.common.base.Optional;
 
+import java.util.Optional;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -37,7 +36,7 @@ public class SuiteReport {
 			}
 		}
 
-		return Optional.absent();
+		return Optional.empty();
 	}
 
 	public Optional<String> getTestDeviceId(Test test) {
@@ -47,7 +46,7 @@ public class SuiteReport {
 			}
 		}
 
-		return Optional.absent();
+		return Optional.empty();
 	}
 
 }


### PR DESCRIPTION
Different guava versions could cause issues for us in the appium client library and for customers who use different guava versions. So I used java 8 instead.