### PR TITLE
RDCCORE-569 Introduce client for JUnit resource

### DIFF
--- a/src/main/java/org/testobject/api/TestObjectClient.java
+++ b/src/main/java/org/testobject/api/TestObjectClient.java
@@ -65,6 +65,8 @@ public interface TestObjectClient extends Closeable {
 
 	String readJunitReport(String apiKey, long testReportId);
 
+	String readJunitReport(String apiKey, List<Long> testReportIds);
+
 	InstrumentationReport waitForInstrumentationReport(String apiKey, long testSuiteReportId, long waitTimeoutMs, long sleepTimeMs)
 			throws TimeoutException;
 

--- a/src/main/java/org/testobject/api/TestObjectClientImpl.java
+++ b/src/main/java/org/testobject/api/TestObjectClientImpl.java
@@ -156,6 +156,11 @@ public class TestObjectClientImpl implements TestObjectClient {
 	}
 
 	@Override
+	public String readJunitReport(String apiKey, List<Long> testReportIds) {
+		return instrumentationResource.getJUnitReport(apiKey, testReportIds);
+	}
+
+	@Override
 	public InstrumentationReport waitForInstrumentationReport(String apiKey, long testSuiteReportId, long waitTimeoutMs, long sleepTimeMs)
 			throws TimeoutException {
 

--- a/src/main/java/org/testobject/rest/api/resource/v2/InstrumentationResource.java
+++ b/src/main/java/org/testobject/rest/api/resource/v2/InstrumentationResource.java
@@ -1,6 +1,5 @@
 package org.testobject.rest.api.resource.v2;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.testobject.rest.api.model.DynamicInstrumentationRequestData;
 import org.testobject.rest.api.model.InstrumentationReport;
 import org.testobject.rest.api.model.StartInstrumentationResponse;
@@ -8,8 +7,6 @@ import org.testobject.rest.api.model.StaticInstrumentationRequestData;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericType;
-
 import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;

--- a/src/main/java/org/testobject/rest/api/resource/v2/InstrumentationResource.java
+++ b/src/main/java/org/testobject/rest/api/resource/v2/InstrumentationResource.java
@@ -1,5 +1,6 @@
 package org.testobject.rest.api.resource.v2;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.testobject.rest.api.model.DynamicInstrumentationRequestData;
 import org.testobject.rest.api.model.InstrumentationReport;
 import org.testobject.rest.api.model.StartInstrumentationResponse;
@@ -7,6 +8,9 @@ import org.testobject.rest.api.model.StaticInstrumentationRequestData;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+
+import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
@@ -71,6 +75,16 @@ public class InstrumentationResource {
 				.request(APPLICATION_XML)
 				.header("Authorization", getApiKeyHeader(apiKey))
 				.get(String.class);
+	}
+
+	public String getJUnitReport(String apiKey, List<Long> reportIds) {
+		return target
+				.path("v2")
+				.path("instrumentation")
+				.path("junitreport")
+				.request(APPLICATION_XML)
+				.header("Authorization", getApiKeyHeader(apiKey))
+				.post(Entity.json(reportIds), String.class);
 	}
 
 	public InstrumentationReport getTestReport(String apiKey, long reportId) {

--- a/src/test/java/org/testobject/api/TestObjectClientTest.java
+++ b/src/test/java/org/testobject/api/TestObjectClientTest.java
@@ -8,12 +8,14 @@ import org.testobject.rest.api.model.SessionReport;
 import org.testobject.rest.api.model.TestSuiteReport;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class TestObjectClientTest {
 
@@ -112,6 +114,15 @@ public class TestObjectClientTest {
 		TestSuiteReport testSuiteReport = client.waitForSuiteReport(suiteId, API_KEY);
 
 		assertEquals(testSuiteReport.getId(), testSuiteReportId);
+	}
+
+	@Test
+	public void readJUnitReport() {
+		List<Long> testReportIds = Collections.singletonList(1L);
+
+		String junitReport = client.readJunitReport(API_KEY, testReportIds);
+		assertNotNull(junitReport);
+		System.out.println(junitReport);
 	}
 
 	@After

--- a/src/test/java/org/testobject/api/TestObjectClientTest.java
+++ b/src/test/java/org/testobject/api/TestObjectClientTest.java
@@ -116,7 +116,7 @@ public class TestObjectClientTest {
 		assertEquals(testSuiteReport.getId(), testSuiteReportId);
 	}
 
-	@Test
+	@Test @Ignore
 	public void readJUnitReport() {
 		List<Long> testReportIds = Collections.singletonList(1L);
 


### PR DESCRIPTION
saucelabs/product#4661 introduced a new resource for downloading a JUnit report including the results for multiple test reports. This PR adds the client for this new resource.

To verify that the new functionality works, I ran the `readJUnitReport` test locally.